### PR TITLE
Delete use of expect command in script

### DIFF
--- a/docker-registry-expect-scripted-login
+++ b/docker-registry-expect-scripted-login
@@ -13,13 +13,6 @@ then
   exit 1
 fi
 
-expect <<EOF
-spawn docker login -u $DOCKER_REGISTRY_USER $DOCKER_REGISTRY_URI
-while (1) {
-  expect {
-    -re ".*Password:.*" { send "$DOCKER_REGISTRY_PASS\r" }
-    -re ".*Your password will be stored unencrypted.*" { send "y\r" }
-    eof { break }
-  }
-}
+docker login -u $DOCKER_REGISTRY_USER --password-stdin $DOCKER_REGISTRY_URI << EOF
+$DOCKER_REGISTRY_PASS
 EOF


### PR DESCRIPTION
Delete expect package use, because on the new ubuntu's AMIs have problem with this package, then we propose use the docker-cli command.